### PR TITLE
Fix base_url assignment in client initialization

### DIFF
--- a/djelia/src/client/client.py
+++ b/djelia/src/client/client.py
@@ -21,7 +21,7 @@ class Djelia:
             self.settings = Settings()
             self.base_url = self.settings.base_url
         else:
-            self.base_url = self.base_url
+            self.base_url = base_url
 
         if api_key is None:
             self.settings = Settings()


### PR DESCRIPTION


# Pull Request

## Description

Fixes incorrect assignment logic for `base_url` during `Client` initialization. Ensures that the explicitly provided `base_url` parameter takes priority instead of reassigning from an uninitialized `self.base_url`.

## Related Issue(s)

N/A

## Changes Made

* Corrected `base_url` assignment so that:

  ```python
  self.base_url = base_url
  ```

  is used instead of mistakenly referencing `self.base_url`.
* No additional documentation or tests needed for this minimal fix.

## Testing

* Manually instantiated `Client` with/without custom `base_url` to confirm expected behavior.
* All tests pass and no linting errors detected.

## Checklist

* [x] Code follows style guidelines (`ruff`, `isort`, optionally `black`).
* [ ] Tests added or updated in the `cookbook` module. *(Not needed for minor logic fix)*
* [ ] Documentation updated *(N/A)*.
* [x] All tests pass.
* [x] No linting errors.

## Additional Notes

This prevents potential bugs in SDK usage when client configuration relies on custom endpoints.

Tag `@sudoping01` for review.
Thanks for contributing to Djelia Python SDK! ❤️🇲🇱


